### PR TITLE
Version 2.3.0

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,10 +1,37 @@
 <component name="InspectionProjectProfileManager">
   <profile version="1.0">
     <option name="myName" value="Project Default" />
+    <inspection_tool class="ComposePreviewDimensionRespectsLimit" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="ComposePreviewMustBeTopLevelFunction" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="ComposePreviewNeedsComposableAnnotation" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="ComposePreviewNotSupportedInUnitTestFiles" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="GlancePreviewDimensionRespectsLimit" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="GlancePreviewMustBeTopLevelFunction" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="GlancePreviewNeedsComposableAnnotation" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="GlancePreviewNotSupportedInUnitTestFiles" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
     <inspection_tool class="PreviewAnnotationInFunctionWithParameters" enabled="true" level="ERROR" enabled_by_default="true">
       <option name="composableFile" value="true" />
     </inspection_tool>
     <inspection_tool class="PreviewApiLevelMustBeValid" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewDeviceShouldUseNewSpec" enabled="true" level="WEAK WARNING" enabled_by_default="true">
       <option name="composableFile" value="true" />
     </inspection_tool>
     <inspection_tool class="PreviewDimensionRespectsLimit" enabled="true" level="WARNING" enabled_by_default="true">

--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="2.0.21" />
+    <option name="version" value="2.1.0" />
   </component>
 </project>

--- a/ImagePickerAndroid/build.gradle.kts
+++ b/ImagePickerAndroid/build.gradle.kts
@@ -97,7 +97,7 @@ afterEvaluate {
             register<MavenPublication>("release") {
                 groupId = "com.github.NicosNicolaou16"
                 artifactId = "ImagePickerAndroid"
-                version = "2.2.1"
+                version = "2.3.0"
                 from(components["release"])
             }
         }

--- a/ImagePickerAndroid/src/main/java/com/nicos/imagepickerandroid/image_picker/ImagePicker.kt
+++ b/ImagePickerAndroid/src/main/java/com/nicos/imagepickerandroid/image_picker/ImagePicker.kt
@@ -7,10 +7,12 @@ import android.content.Intent
 import android.graphics.Bitmap
 import android.net.Uri
 import android.provider.MediaStore
+import android.provider.Settings
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.IntRange
+import androidx.core.app.ActivityCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import com.nicos.imagepickerandroid.utils.image_helper_methods.ImageHelperMethods
@@ -284,14 +286,38 @@ data class ImagePicker(
                 if (permissionsHelper?.isPermissionGranted(it) == true)
                     takeAPhotoWithCameraResultLauncher?.launch(this)
                 else {
-                    permissionsHelper?.activityResultLauncherPermissionActivity?.launch(Manifest.permission.CAMERA)
+                    if (ActivityCompat.shouldShowRequestPermissionRationale(
+                            it,
+                            Manifest.permission.CAMERA
+                        )
+                    ) {
+                        it.startActivity(Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
+                            data = Uri.fromParts("package", it.packageName, null)
+                            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                        })
+                    } else {
+                        permissionsHelper?.activityResultLauncherPermissionActivity?.launch(Manifest.permission.CAMERA)
+
+                    }
                 }
             }
             fragment?.let {
                 if (permissionsHelper?.isPermissionGranted(it) == true)
                     takeAPhotoWithCameraResultLauncher?.launch(this)
                 else {
-                    permissionsHelper?.activityResultLauncherPermissionFragment?.launch(Manifest.permission.CAMERA)
+                    if (ActivityCompat.shouldShowRequestPermissionRationale(
+                            it.requireActivity(),
+                            Manifest.permission.CAMERA
+                        )
+                    ) {
+                        it.startActivity(Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
+                            data = Uri.fromParts("package", it.context?.packageName, null)
+                            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                        })
+                    } else {
+                        permissionsHelper?.activityResultLauncherPermissionFragment?.launch(Manifest.permission.CAMERA)
+
+                    }
                 }
             }
         }

--- a/ImagePickerAndroid/src/main/java/com/nicos/imagepickerandroid/image_picker/ImagePickerCompose.kt
+++ b/ImagePickerAndroid/src/main/java/com/nicos/imagepickerandroid/image_picker/ImagePickerCompose.kt
@@ -1,16 +1,28 @@
 package com.nicos.imagepickerandroid.image_picker
 
 import android.Manifest
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
 import android.graphics.Bitmap
 import android.net.Uri
+import android.provider.Settings
 import androidx.activity.compose.ManagedActivityResultLauncher
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.IntRange
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalContext
+import androidx.core.app.ActivityCompat
+import androidx.core.app.ActivityCompat.shouldShowRequestPermissionRationale
 import com.nicos.imagepickerandroid.utils.image_helper_methods.ImageHelperMethods
 import com.nicos.imagepickerandroid.utils.image_helper_methods.ScaleBitmapModel
 import kotlinx.coroutines.Dispatchers
@@ -289,17 +301,26 @@ fun CameraPermission() {
     permissionLauncher = rememberLauncherForActivityResult(
         ActivityResultContracts.RequestPermission()
     ) { isGranted ->
-        if (isGranted) {
-            takeCameraImage?.launch(null)
-        }
+        if (isGranted) takeCameraImage?.launch(null)
     }
 }
 
 /**
  * This method is calling from listener to pick single image from camera
  * */
-fun takeSingleCameraImage() {
-    permissionLauncher?.launch(Manifest.permission.CAMERA)
+fun takeSingleCameraImage(context: Context) {
+    if (shouldShowRequestPermissionRationale(
+            context as Activity,
+            Manifest.permission.CAMERA
+        )
+    ) {
+        context.startActivity(Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
+            data = Uri.fromParts("package", context.packageName, null)
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        })
+    } else {
+        permissionLauncher?.launch(Manifest.permission.CAMERA)
+    }
 }
 
 /**
@@ -347,8 +368,19 @@ fun TakeSingleCameraImageWithBase64Value(
 /**
  * This method is calling from listener to pick single image from camera with base64 values
  * */
-fun takeSingleCameraImageWithBase64Value() {
-    takeCameraImageWithBase64Value?.launch(null)
+fun takeSingleCameraImageWithBase64Value(context: Context) {
+    if (shouldShowRequestPermissionRationale(
+            context as Activity,
+            Manifest.permission.CAMERA
+        )
+    ) {
+        context.startActivity(Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
+            data = Uri.fromParts("package", context.packageName, null)
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        })
+    } else {
+        takeCameraImageWithBase64Value?.launch(null)
+    }
 }
 
 /**

--- a/README.md
+++ b/README.md
@@ -27,13 +27,14 @@ Build Tool Version 35 <br />
 
 ## IMPORTANT NOTE
 
-THE BETA RELEASES MAYBE CONTAIN MAJOR/MINOR CHANGES
+THE BETA RELEASES MAYBE CONTAIN MAJOR/MINOR CHANGES <br /> <br />
 
-> [!IMPORTANT]  Breaking changes for the version: 2.3.0
+> [!IMPORTANT]  
+> Breaking changes for the version: 2.3.0
 
-`takeSingleCameraImage()` changed to `takeSingleCameraImage(context = context)`
+> `takeSingleCameraImage()` changed to `takeSingleCameraImage(context = context)`
 
-`takeSingleCameraImageWithBase64Value()` changed to
+> `takeSingleCameraImageWithBase64Value()` changed to
 `takeSingleCameraImageWithBase64Value(context = context)`
 
 ## Basic Configuration

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Build Tool Version 35 <br />
 THE BETA RELEASES MAYBE CONTAIN MAJOR/MINOR CHANGES <br /> <br />
 
 > [!IMPORTANT]  
-> Breaking changes for the version: 2.3.0 <br /> <br />
+> Breaking changes for the version 2.3.0 <br /> <br />
 > `takeSingleCameraImage()` changed to `takeSingleCameraImage(context = context)` <br /> <br />
 > `takeSingleCameraImageWithBase64Value()` changed to
 `takeSingleCameraImageWithBase64Value(context = context)`

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ THE BETA RELEASES MAYBE CONTAIN MAJOR/MINOR CHANGES <br /> <br />
 ### Groovy
 
 ```Groovy
-implementation 'com.github.NicosNicolaou16:ImagePickerAndroid:2.2.1'
+implementation 'com.github.NicosNicolaou16:ImagePickerAndroid:2.3.0'
 ```
 
 ```Groovy
@@ -56,7 +56,7 @@ allprojects {
 ### Kotlin DSL
 
 ```Kotlin
-implementation("com.github.NicosNicolaou16:ImagePickerAndroid:2.2.1")
+implementation("com.github.NicosNicolaou16:ImagePickerAndroid:2.3.0")
 ```
 
 ```Kotlin
@@ -74,7 +74,7 @@ dependencyResolutionManagement {
 ```toml
 [versions]
 # other versions here...
-imagePickerAndroid = "2.2.1"
+imagePickerAndroid = "2.3.0"
 
 [libraries]
 # other libraries here...

--- a/README.md
+++ b/README.md
@@ -29,6 +29,13 @@ Build Tool Version 35 <br />
 
 THE BETA RELEASES MAYBE CONTAIN MAJOR/MINOR CHANGES
 
+## Breaking changes for the version: 2.3.0
+
+`takeSingleCameraImage()` changed to `takeSingleCameraImage(context = context)`
+
+`takeSingleCameraImageWithBase64Value()` changed to
+`takeSingleCameraImageWithBase64Value(context = context)`
+
 ## Basic Configuration
 
 [![](https://jitpack.io/v/NicosNicolaou16/ImagePickerAndroid.svg)](https://jitpack.io/#NicosNicolaou16/ImagePickerAndroid)
@@ -88,13 +95,6 @@ dependencyResolutionManagement {
     }
 }
 ```
-
-## Breaking changes for the version: 2.3.0
-
-`takeSingleCameraImage()` changed to `takeSingleCameraImage(context = context)`
-
-`takeSingleCameraImageWithBase64Value()` changed to
-`takeSingleCameraImageWithBase64Value(context = context)`
 
 ## Standard Configuration
 
@@ -272,9 +272,9 @@ pickMultipleImages()
 
 pickMultipleImagesWithBase64Values()
 
-takeSingleCameraImage()
+takeSingleCameraImage(context = context)
 
-takeCameraImageWithBase64Value()
+takeSingleCameraImageWithBase64Value(context = context)
 
 pickSingleVideo()
 ```

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The library contain/features:
 
 ### Versioning
 
-Gradle Version 8.7.2 <br />
+Gradle Version 8.7.3 <br />
 Kotlin Version 2.1.0 <br />
 JDK Version 17 <br />
 Minimum SDK 24 <br />

--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ The library contains/features:
 - All of the above features are also supported in Jetpack Compose.
 - New updates coming soon! Feel free to share your suggestions.
 
+Reasons to use this library
+
+- It supports both Activity and Fragment with XML, as well as Jetpack Compose, ensuring compatibility with various Android development approaches.
+- The library provides a user-friendly way to integrate image picking functionalities, saving time and effort.
+- It offers advanced features like base64 encoding support and image scaling, enhancing your app's image handling capabilities.
+
 ### Versioning
 
 Gradle Version 8.7.3 <br />

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ dependencyResolutionManagement {
 }
 ```
 
-## Breaking changes for latest version (Version: 2.3.0)
+## Breaking changes for the version: 2.3.0
 
 `takeSingleCameraImage()` changed to `takeSingleCameraImage(context = context)`
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ THE BETA RELEASES MAY CONTAIN MAJOR OR MINOR CHANGES. <br /> <br />
 > `takeSingleCameraImageWithBase64Value()` changed to
 `takeSingleCameraImageWithBase64Value(context = context)`
 
-## Basic Configuration
+## Basic Configuration (Gradle Dependencies)
 
 [![](https://jitpack.io/v/NicosNicolaou16/ImagePickerAndroid.svg)](https://jitpack.io/#NicosNicolaou16/ImagePickerAndroid)
 
@@ -96,7 +96,7 @@ dependencyResolutionManagement {
 }
 ```
 
-## Standard Configuration
+## Standard Configuration (XML)
 
 ### Step 1 - Get Instance
 

--- a/README.md
+++ b/README.md
@@ -90,24 +90,10 @@ dependencyResolutionManagement {
 
 ## Braking changes for latest version
 
-```kotlin
-/**
- * Before
- */
-`takeSingleCameraImage()`
-/**
- * Now
- */
-`takeSingleCameraImage(context = context)`
+```text
+`takeSingleCameraImage()` changed to `takeSingleCameraImage(context = context)`
 
-/**
- * Before
- */
-`takeSingleCameraImageWithBase64Value()`
-/**
- * Now
- */
-`takeSingleCameraImageWithBase64Value(context = context)`
+`takeSingleCameraImageWithBase64Value()` changed to `takeSingleCameraImageWithBase64Value(context = context)`
 ```
 
 ## Standard Configuration

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ dependencyResolutionManagement {
 }
 ```
 
-## Braking changes for latest version
+## Breaking changes for latest version (Version: 2.3.0)
 
 `takeSingleCameraImage()` changed to `takeSingleCameraImage(context = context)`
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,8 @@ dependencyResolutionManagement {
 
 `takeSingleCameraImage()` changed to `takeSingleCameraImage(context = context)`
 
-`takeSingleCameraImageWithBase64Value()` changed to `takeSingleCameraImageWithBase64Value(context = context)`
+`takeSingleCameraImageWithBase64Value()` changed to
+`takeSingleCameraImageWithBase64Value(context = context)`
 
 ## Standard Configuration
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ The library contains/features:
 
 - Picker for a single image from the gallery.
 - Picker for multiple images from the gallery (up to 9 images).
-- Camera picker for a single image (with permission handling - manage the scenario where camera permission is permanently denied by directing the user to the app settings to modify the permission).
+- Camera picker for a single image (with permission handling - manage the scenario where camera
+  permission is permanently denied by directing the user to the app settings to modify the
+  permission).
 - Video picker.
 - Retrieve the base64 value.
 - Image scaling (resize) – available only for images.

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ Build Tool Version 35 <br />
 THE BETA RELEASES MAYBE CONTAIN MAJOR/MINOR CHANGES <br /> <br />
 
 > [!IMPORTANT]  
-> Breaking changes for the version: 2.3.0
-> `takeSingleCameraImage()` changed to `takeSingleCameraImage(context = context)`
+> Breaking changes for the version: 2.3.0 <br /> <br />
+> `takeSingleCameraImage()` changed to `takeSingleCameraImage(context = context)` <br /> <br />
 > `takeSingleCameraImageWithBase64Value()` changed to
 `takeSingleCameraImageWithBase64Value(context = context)`
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Image Picker Android
 
-This library built to give to other developers an easy way to implement the image picker in Android
-application with latest Android technologies. Its supports Activity, Fragment with XML and Jetpack
-Compose.<br />
-Support me and I will appreciate if you provide me your feedback(s).<br />
-Note: The example project doesn't contain all the examples for all methods.
+This library is built to provide other developers with an easy way to implement an image picker in
+Android applications using the latest Android technologies. It supports Activities, Fragments with
+XML, and Jetpack Compose.
+Support me, and I would appreciate any feedback you provide. <br />
+Note: The example project does not include examples for all methods.
 
 The library contains/features:
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,28 @@ dependencyResolutionManagement {
 }
 ```
 
+## Braking changes for latest version
+
+```kotlin
+/**
+ * Before
+ */
+`takeSingleCameraImage()`
+/**
+ * Now
+ */
+`takeSingleCameraImage(context = context)`
+
+/**
+ * Before
+ */
+`takeSingleCameraImageWithBase64Value()`
+/**
+ * Now
+ */
+`takeSingleCameraImageWithBase64Value(context = context)`
+```
+
 ## Standard Configuration
 
 ### Step 1 - Get Instance

--- a/README.md
+++ b/README.md
@@ -6,15 +6,16 @@ Compose.<br />
 Support me and I will appreciate if you provide me your feedback(s).<br />
 Note: The example project doesn't contain all the examples for all methods.
 
-The library contain/features:
+The library contains/features:
 
-- Picker for single image from gallery
-- Picker for multiple images from gallery (up to 9 images)
-- Take single image from camera (handled permission)
-- Video Picker
-- Support for the base64 value and scale (resize) are only for image
-- All the previous features supported on Jetpack Compose too
-- New updates coming soon and tell me your suggestions...
+- Picker for a single image from the gallery
+- Picker for multiple images from the gallery (up to 9 images)
+- Camera picker for a single image (with permission handling)
+- Video picker
+- Retrieve the base64 value
+- Image scaling (resize) – available only for images
+- All of the above features are also supported in Jetpack Compose
+- New updates coming soon! Feel free to share your suggestions.
 
 ### Versioning
 
@@ -27,7 +28,7 @@ Build Tool Version 35 <br />
 
 ## IMPORTANT NOTE
 
-THE BETA RELEASES MAYBE CONTAIN MAJOR/MINOR CHANGES <br /> <br />
+THE BETA RELEASES MAY CONTAIN MAJOR OR MINOR CHANGES. <br /> <br />
 
 > [!IMPORTANT]  
 > Breaking changes for the version 2.3.0 <br /> <br />

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Build Tool Version 35 <br />
 
 THE BETA RELEASES MAYBE CONTAIN MAJOR/MINOR CHANGES
 
-## Breaking changes for the version: 2.3.0
+> [!IMPORTANT]  Breaking changes for the version: 2.3.0
 
 `takeSingleCameraImage()` changed to `takeSingleCameraImage(context = context)`
 

--- a/README.md
+++ b/README.md
@@ -31,9 +31,7 @@ THE BETA RELEASES MAYBE CONTAIN MAJOR/MINOR CHANGES <br /> <br />
 
 > [!IMPORTANT]  
 > Breaking changes for the version: 2.3.0
-
 > `takeSingleCameraImage()` changed to `takeSingleCameraImage(context = context)`
-
 > `takeSingleCameraImageWithBase64Value()` changed to
 `takeSingleCameraImageWithBase64Value(context = context)`
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The library contains/features:
 
 - Picker for a single image from the gallery.
 - Picker for multiple images from the gallery (up to 9 images).
-- Camera picker for a single image (with permission handling).
+- Camera picker for a single image (with permission handling - manage the scenario where camera permission is permanently denied by directing the user to the app settings to modify the permission).
 - Video picker.
 - Retrieve the base64 value.
 - Image scaling (resize) – available only for images.

--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ Note: The example project does not include examples for all methods.
 
 The library contains/features:
 
-- Picker for a single image from the gallery
-- Picker for multiple images from the gallery (up to 9 images)
-- Camera picker for a single image (with permission handling)
-- Video picker
-- Retrieve the base64 value
-- Image scaling (resize) – available only for images
-- All of the above features are also supported in Jetpack Compose
+- Picker for a single image from the gallery.
+- Picker for multiple images from the gallery (up to 9 images).
+- Camera picker for a single image (with permission handling).
+- Video picker.
+- Retrieve the base64 value.
+- Image scaling (resize) – available only for images.
+- All of the above features are also supported in Jetpack Compose.
 - New updates coming soon! Feel free to share your suggestions.
 
 ### Versioning

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # Image Picker Android
 
 This library built to give to other developers an easy way to implement the image picker in Android
-application with latest Android technologies. Its supports Activity, Fragment with XML and Jetpack Compose.<br />
+application with latest Android technologies. Its supports Activity, Fragment with XML and Jetpack
+Compose.<br />
 Support me and I will appreciate if you provide me your feedback(s).<br />
 Note: The example project doesn't contain all the examples for all methods.
 
@@ -90,11 +91,9 @@ dependencyResolutionManagement {
 
 ## Braking changes for latest version
 
-```text
 `takeSingleCameraImage()` changed to `takeSingleCameraImage(context = context)`
 
 `takeSingleCameraImageWithBase64Value()` changed to `takeSingleCameraImageWithBase64Value(context = context)`
-```
 
 ## Standard Configuration
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id("com.android.application") version "8.7.2" apply false
-    id("com.android.library") version "8.7.2" apply false
+    id("com.android.application") version "8.7.3" apply false
+    id("com.android.library") version "8.7.3" apply false
     id("org.jetbrains.kotlin.android") version "2.1.0" apply false
 }

--- a/imagepickerandroidcompose/build.gradle.kts
+++ b/imagepickerandroidcompose/build.gradle.kts
@@ -51,7 +51,7 @@ android {
 dependencies {
     implementation(project(":ImagePickerAndroid"))
     implementation("androidx.core:core-ktx:1.15.0")
-    implementation(platform("org.jetbrains.kotlin:kotlin-bom:2.0.21"))
+    implementation(platform("org.jetbrains.kotlin:kotlin-bom:2.1.0"))
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.8.7")
     implementation("androidx.activity:activity-compose:1.9.3")
     implementation(platform("androidx.compose:compose-bom:2024.11.00"))

--- a/imagepickerandroidcompose/build.gradle.kts
+++ b/imagepickerandroidcompose/build.gradle.kts
@@ -66,6 +66,6 @@ dependencies {
     androidTestImplementation("androidx.compose.ui:ui-test-junit4")
     debugImplementation("androidx.compose.ui:ui-tooling")
     debugImplementation("androidx.compose.ui:ui-test-manifest:1.7.5")
-    implementation("androidx.media3:media3-exoplayer:1.4.1")
-    implementation("androidx.media3:media3-ui:1.4.1")
+    implementation("androidx.media3:media3-exoplayer:1.5.0")
+    implementation("androidx.media3:media3-ui:1.5.0")
 }

--- a/imagepickerandroidcompose/src/main/java/com/nicos/imagepickerandroidcompose/MainActivity.kt
+++ b/imagepickerandroidcompose/src/main/java/com/nicos/imagepickerandroidcompose/MainActivity.kt
@@ -171,7 +171,7 @@ fun ImagePicker() {
                 style = TextStyle(textAlign = TextAlign.Center)
             )
         }
-        Button(modifier = Modifier.size(150.dp, 50.dp), onClick = { takeSingleCameraImage() }) {
+        Button(modifier = Modifier.size(150.dp, 50.dp), onClick = { takeSingleCameraImage(context = context) }) {
             Text(
                 text = stringResource(R.string.take_camera_images),
                 style = TextStyle(textAlign = TextAlign.Center)


### PR DESCRIPTION
  What's new:
- Update Gradle version to 8.7.2.
- Update Kotlin version to 2.1.0.
- Update Media3 version to 1.5.0.
- Breaking Changes
  - Manage the scenario where camera permission is permanently denied by directing the user to the app settings to modify the permission. You should migrate the camera image method to the following code. (issue number)
    - `takeSingleCameraImage()` changed to `takeSingleCameraImage(context = context)`
    - `takeSingleCameraImageWithBase64Value()` changed to `takeSingleCameraImageWithBase64Value(context = context)`
- Refactor README file.
- Minor fixes.