### PR TITLE
Version2.4.1

### DIFF
--- a/ImagePickerAndroid/build.gradle.kts
+++ b/ImagePickerAndroid/build.gradle.kts
@@ -81,7 +81,7 @@ afterEvaluate {
             register<MavenPublication>("release") {
                 groupId = "com.github.NicosNicolaou16"
                 artifactId = "ImagePickerAndroid"
-                version = "2.4.0"
+                version = "2.4.1"
                 from(components["release"])
             }
         }

--- a/ImagePickerAndroid/src/main/AndroidManifest.xml
+++ b/ImagePickerAndroid/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-feature
         android:name="android.hardware.camera"
@@ -9,9 +10,11 @@
     <application>
         <provider
             android:name="androidx.core.content.FileProvider"
-            android:authorities="${applicationId}.fileprovider"
+            tools:node="remove"
+            android:authorities="com.nicos.imagepickerandroidcompose.library.file.provider"
             android:exported="false"
-            android:grantUriPermissions="true">
+            android:grantUriPermissions="true"
+            tools:replace="android:authorities">
             <meta-data
                 android:name="android.support.FILE_PROVIDER_PATHS"
                 android:resource="@xml/file_path" />

--- a/ImagePickerAndroid/src/main/AndroidManifest.xml
+++ b/ImagePickerAndroid/src/main/AndroidManifest.xml
@@ -10,10 +10,10 @@
     <application>
         <provider
             android:name="androidx.core.content.FileProvider"
-            tools:node="remove"
             android:authorities="com.nicos.imagepickerandroidcompose.library.file.provider"
             android:exported="false"
             android:grantUriPermissions="true"
+            tools:node="remove"
             tools:replace="android:authorities">
             <meta-data
                 android:name="android.support.FILE_PROVIDER_PATHS"

--- a/ImagePickerAndroid/src/main/java/com/nicos/imagepickerandroid/utils/extensions/extensions.kt
+++ b/ImagePickerAndroid/src/main/java/com/nicos/imagepickerandroid/utils/extensions/extensions.kt
@@ -5,11 +5,13 @@ import android.net.Uri
 import androidx.core.content.FileProvider
 import java.io.File
 
+private const val authority = ".library.file.provider"
+
 internal fun File.getUriWithFileProvider(context: Context): Uri {
     require(!this.exists()) { "File must exist to get a URI with FileProvider" }
     return FileProvider.getUriForFile(
         context,
-        "${context.packageName}.fileprovider",
+        "${context.packageName}$authority",
         this // 'this' refers to the File instance the extension is called on
     )
 }

--- a/imagepickerandroidcompose/src/main/java/com/nicos/imagepickerandroidcompose/MainActivity.kt
+++ b/imagepickerandroidcompose/src/main/java/com/nicos/imagepickerandroidcompose/MainActivity.kt
@@ -24,7 +24,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.asImageBitmap


### PR DESCRIPTION
### **What's new:**
- Fixed a manifest merge conflict related to FileProvider definitions. The issue occurred when both the app and the library defined conflicting FileProvider entries, causing build failures. This has now been resolved. ([Issue #16](https://github.com/NicosNicolaou16/ImagePickerAndroid/issues/16))