### PR TITLE
Version2.4.2

### DIFF
--- a/ImagePickerAndroid/build.gradle.kts
+++ b/ImagePickerAndroid/build.gradle.kts
@@ -81,7 +81,7 @@ afterEvaluate {
             register<MavenPublication>("release") {
                 groupId = "com.github.NicosNicolaou16"
                 artifactId = "ImagePickerAndroid"
-                version = "2.4.1"
+                version = "2.4.2"
                 from(components["release"])
             }
         }

--- a/ImagePickerAndroid/src/main/AndroidManifest.xml
+++ b/ImagePickerAndroid/src/main/AndroidManifest.xml
@@ -9,12 +9,10 @@
 
     <application>
         <provider
-            android:name="androidx.core.content.FileProvider"
-            android:authorities="com.nicos.imagepickerandroidcompose.library.file.provider"
+            android:name="com.nicos.imagepickerandroid.utils.my_library_file_provider.MyLibraryFileProvider"
+            android:authorities="com.nick.imagepickerandroid.library.file.provider"
             android:exported="false"
-            android:grantUriPermissions="true"
-            tools:node="remove"
-            tools:replace="android:authorities">
+            android:grantUriPermissions="true">
             <meta-data
                 android:name="android.support.FILE_PROVIDER_PATHS"
                 android:resource="@xml/file_path" />

--- a/ImagePickerAndroid/src/main/java/com/nicos/imagepickerandroid/utils/my_library_file_provider/MyLibraryFileProvider.kt
+++ b/ImagePickerAndroid/src/main/java/com/nicos/imagepickerandroid/utils/my_library_file_provider/MyLibraryFileProvider.kt
@@ -1,0 +1,5 @@
+package com.nicos.imagepickerandroid.utils.my_library_file_provider
+
+import androidx.core.content.FileProvider
+
+class MyLibraryFileProvider : FileProvider()


### PR DESCRIPTION
### **What's new:**
- Fixed a manifest merge conflict related to FileProvider definitions. The issue occurred when both the app and the library defined conflicting FileProvider entries, causing build failures. This has now been resolved. ([Issue #16](https://github.com/NicosNicolaou16/ImagePickerAndroid/issues/16))
  - Bug fixes.